### PR TITLE
支持更多的 CSS 颜色类型

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "typescript": "^5.3.0",
     "vite": "^5.0.0",
     "vite-plugin-dts": "^3.6.0"
+  },
+  "dependencies": {
+    "colorjs.io": "^0.5.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      colorjs.io:
+        specifier: ^0.5.2
+        version: 0.5.2
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -561,6 +565,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorjs.io@0.5.2:
+    resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1642,6 +1649,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorjs.io@0.5.2: {}
 
   commander@2.20.3: {}
 

--- a/public/iconset.svg
+++ b/public/iconset.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" standalone="no"?>
 <!-- The icon set is based on Material Design icons by Google (https://github.com/google/material-design-icons) -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg viewBox="0 0 48 48" style="background-color:#ffffff00" version="1.1"
+<svg viewBox="0 0 48 48" style="background-color:#ffffff00;color:green" version="1.1"
   xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve"
 >
   <g id="3d_rotation" style="display:none">
-    <path d="M 15 43 C 8.5 39.9 3.8 33.5 3.1 26 L 0.1 26 C 1.1 38.3 11.4 48 24 48 C 24.4 48 24.9 48 25.3 47.9 L 17.7 40.3 L 15 43 L 15 43 Z" fill="#336699"/>
-    <path d="M 32 26 C 32 27.1 31.1 28 30 28 L 28 28 L 28 20 L 30 20 C 31.1 20 32 20.9 32 22 L 32 26 M 30 16 L 24 16 L 24 32 L 30 32 C 33.3 32 36 29.3 36 26 L 36 22 C 36 18.7 33.3 16 30 16 L 30 16 Z" fill="#336699"/>
-    <path d="M 22 28 L 22 26 C 22 24.9 21.1 24 20 24 C 21.1 24 22 23.1 22 22 L 22 20 C 22 17.8 20.2 16 18 16 L 12 16 L 12 20 L 18 20 L 18 22 L 14 22 L 14 26 L 18 26 L 18 27.9 L 18 28 L 18 28 L 18 28 L 18 28 L 12 28 L 12 32 L 18 32 C 20.2 32 22 30.2 22 28 L 22 28 Z" fill="#336699"/>
-    <path d="M 24 0 C 23.6 0 23.1 0 22.7 0.1 L 30.3 7.7 L 33 5 C 39.5 8.1 44.2 14.4 44.9 22 L 47.9 22 C 46.9 9.7 36.6 0 24 0 L 24 0 Z" fill="#336699"/>
+    <path d="M 15 43 C 8.5 39.9 3.8 33.5 3.1 26 L 0.1 26 C 1.1 38.3 11.4 48 24 48 C 24.4 48 24.9 48 25.3 47.9 L 17.7 40.3 L 15 43 L 15 43 Z" fill="currentColor"/>
+    <path d="M 32 26 C 32 27.1 31.1 28 30 28 L 28 28 L 28 20 L 30 20 C 31.1 20 32 20.9 32 22 L 32 26 M 30 16 L 24 16 L 24 32 L 30 32 C 33.3 32 36 29.3 36 26 L 36 22 C 36 18.7 33.3 16 30 16 L 30 16 Z" fill="currentColor"/>
+    <path d="M 22 28 L 22 26 C 22 24.9 21.1 24 20 24 C 21.1 24 22 23.1 22 22 L 22 20 C 22 17.8 20.2 16 18 16 L 12 16 L 12 20 L 18 20 L 18 22 L 14 22 L 14 26 L 18 26 L 18 27.9 L 18 28 L 18 28 L 18 28 L 18 28 L 12 28 L 12 32 L 18 32 C 20.2 32 22 30.2 22 28 L 22 28 Z" fill="currentColor"/>
+    <path d="M 24 0 C 23.6 0 23.1 0 22.7 0.1 L 30.3 7.7 L 33 5 C 39.5 8.1 44.2 14.4 44.9 22 L 47.9 22 C 46.9 9.7 36.6 0 24 0 L 24 0 Z" fill="currentColor"/>
   </g>
   <g id="accessibility" style="display:none">
     <path d="M 42 18 L 30 18 L 30 44 L 26 44 L 26 32 L 22 32 L 22 44 L 18 44 L 18 18 L 6 18 L 6 14 L 42 14 L 42 18 Z" fill="#336699"/>

--- a/src/easings.ts
+++ b/src/easings.ts
@@ -1,68 +1,55 @@
 // Easing functions collection - from easings.js
-export const easings: any = {};
-easings['circ-in']=function (t: any) {
-  return -1 * (Math.sqrt(1 - t*t) - 1);
+export const easings = {
+  ['circ-in']: (t: number) => -1 * (Math.sqrt(1 - t * t) - 1),
+  ['circ-out']: (t: number) => Math.sqrt(1 - (t = t - 1) * t),
+  ['circ-in-out']: (t: number) => {
+    if ((t /= 1 / 2) < 1) return -1 / 2 * (Math.sqrt(1 - t * t) - 1);
+    return 1 / 2 * (Math.sqrt(1 - (t -= 2) * t) + 1);
+  },
+  ['cubic-in']: (t: number) => t * t * t,
+  ['cubic-out']: (t: number) => (--t) * t * t + 1,
+  ['cubic-in-out']: (t: number) => t < .5 ? 4 * t * t * t : (t - 1) * (2 * t - 2) * (2 * t - 2) + 1,
+  ['elastic-in']: (t: number) => {
+    var s = 1.70158; var p = 0; var a = 1;
+    if (t == 0) return 0; if (t == 1) return 1; if (!p) p = .3;
+    if (a < Math.abs(1)) { a = 1; var s = p / 4; }
+    else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+    return -(a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p));
+  },
+  ['elastic-out']: (t: number) => {
+    var s = 1.70158; var p = 0; var a = 1;
+    if (t == 0) return 0; if (t == 1) return 1; if (!p) p = .3;
+    if (a < Math.abs(1)) { a = 1; var s = p / 4; }
+    else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+    return a * Math.pow(2, -10 * t) * Math.sin((t - s) * (2 * Math.PI) / p) + 1;
+  },
+  ['elastic-in-out']: (t: number) => {
+    var s = 1.70158; var p = 0; var a = 1;
+    if (t == 0) return 0; if ((t /= 1 / 2) == 2) return 1; if (!p) p = 1 * (.3 * 1.5);
+    if (a < Math.abs(1)) { a = 1; var s = p / 4; }
+    else var s = p / (2 * Math.PI) * Math.asin(1 / a);
+    if (t < 1) return -.5 * (a * Math.pow(2, 10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p));
+    return a * Math.pow(2, -10 * (t -= 1)) * Math.sin((t - s) * (2 * Math.PI) / p) * .5 + 1;
+  },
+  ['expo-in']: (t: number) => (t == 0) ? 0 : Math.pow(2, 10 * (t - 1)),
+  ['expo-out']: (t: number) => (t == 1) ? 1 : 1 - Math.pow(2, -10 * t),
+  ['expo-in-out']: (t: number) => {
+    if (t == 0) return 0;
+    if (t == 1) return 1;
+    if ((t /= 1 / 2) < 1) return 1 / 2 * Math.pow(2, 10 * (t - 1));
+    return 1 / 2 * (-Math.pow(2, -10 * --t) + 2);
+  },
+  ['linear']: (t: number) => t,
+  ['quad-in']: (t: number) => t * t,
+  ['quad-out']: (t: number) => t * (2 - t),
+  ['quad-in-out']: (t: number) => t < .5 ? 2 * t * t : -1 + (4 - 2 * t) * t,
+  ['quart-in']: (t: number) => t * t * t * t,
+  ['quart-out']: (t: number) => 1 - (--t) * t * t * t,
+  ['quart-in-out']: (t: number) => t < .5 ? 8 * t * t * t * t : 1 - 8 * (--t) * t * t * t,
+  ['quint-in']: (t: number) => t * t * t * t * t,
+  ['quint-out']: (t: number) => 1 + (--t) * t * t * t * t,
+  ['quint-in-out']: (t: number) => t < .5 ? 16 * t * t * t * t * t : 1 + 16 * (--t) * t * t * t * t,
+  ['sine-in']: (t: number) => 1 - Math.cos(t * (Math.PI / 2)),
+  ['sine-out']: (t: number) => Math.sin(t * (Math.PI / 2)),
+  ['sine-in-out']: (t: number) => 1 / 2 * (1 - Math.cos(Math.PI * t)),
 };
-easings['circ-out']=function (t: any) {
-  return Math.sqrt(1 - (t=t-1)*t);
-};
-easings['circ-in-out']=function (t: any) {
-  if ((t/=1/2) < 1) return -1/2 * (Math.sqrt(1 - t*t) - 1);
-  return 1/2 * (Math.sqrt(1 - (t-=2)*t) + 1);
-};
-easings['cubic-in']=function (t: any) { return t*t*t };
-easings['cubic-out']=function (t: any) { return (--t)*t*t+1 };
-easings['cubic-in-out']=function (t: any) { return t<.5 ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1 };
-easings['elastic-in']=function (t: any) {
-  var s=1.70158;var p=0;var a=1;
-  if (t==0) return 0;  if (t==1) return 1;  if (!p) p=.3;
-  if (a < Math.abs(1)) { a=1; var s=p/4; }
-  else var s = p/(2*Math.PI) * Math.asin (1/a);
-  return -(a*Math.pow(2,10*(t-=1)) * Math.sin( (t-s)*(2*Math.PI)/p ));
-};
-easings['elastic-out']=function (t: any) {
-  var s=1.70158;var p=0;var a=1;
-  if (t==0) return 0;  if (t==1) return 1;  if (!p) p=.3;
-  if (a < Math.abs(1)) { a=1; var s=p/4; }
-  else var s = p/(2*Math.PI) * Math.asin (1/a);
-  return a*Math.pow(2,-10*t) * Math.sin( (t-s)*(2*Math.PI)/p ) + 1;
-};
-easings['elastic-in-out']=function (t: any) {
-  var s=1.70158;var p=0;var a=1;
-  if (t==0) return 0;  if ((t/=1/2)==2) return 1;  if (!p) p=1*(.3*1.5);
-  if (a < Math.abs(1)) { a=1; var s=p/4; }
-  else var s = p/(2*Math.PI) * Math.asin (1/a);
-  if (t < 1) return -.5*(a*Math.pow(2,10*(t-=1)) * Math.sin( (t-s)*(2*Math.PI)/p ));
-  return a*Math.pow(2,-10*(t-=1)) * Math.sin( (t-s)*(2*Math.PI)/p )*.5 + 1;
-};
-easings['expo-in']=function (t: any) {
-  return (t==0) ? 0 : Math.pow(2, 10 * (t - 1));
-};
-easings['expo-out']=function (t: any) {
-  return (t==1) ? 1 : 1-Math.pow(2, -10 * t);
-};
-easings['expo-in-out']=function (t: any) {
-  if (t==0) return 0;
-  if (t==1) return 1;
-  if ((t/=1/2) < 1) return 1/2 * Math.pow(2, 10 * (t - 1));
-  return 1/2 * (-Math.pow(2, -10 * --t) + 2);
-};
-easings['linear']=function (t: any) { return t };
-easings['quad-in']=function (t: any) { return t*t };
-easings['quad-out']=function (t: any) { return t*(2-t) };
-easings['quad-in-out']=function (t: any) { return t<.5 ? 2*t*t : -1+(4-2*t)*t };
-easings['quart-in']=function (t: any) { return t*t*t*t };
-easings['quart-out']=function (t: any) { return 1-(--t)*t*t*t };
-easings['quart-in-out']=function (t: any) { return t<.5 ? 8*t*t*t*t : 1-8*(--t)*t*t*t };
-easings['quint-in']=function (t: any) { return t*t*t*t*t };
-easings['quint-out']=function (t: any) { return 1+(--t)*t*t*t*t };
-easings['quint-in-out']=function (t: any) { return t<.5 ? 16*t*t*t*t*t : 1+16*(--t)*t*t*t*t };
-easings['sine-in']=function (t: any) {
-  return 1-Math.cos(t * (Math.PI/2));
-};
-easings['sine-out']=function (t: any) {
-  return Math.sin(t * (Math.PI/2));
-};
-easings['sine-in-out']=function (t: any) {
-  return 1/2 * (1-Math.cos(Math.PI*t));
-}; 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,29 +1,5 @@
 import Color from 'colorjs.io';
 
-// 定义包含浏览器前缀方法的接口
-interface ExtendedWindow extends Window {
-  mozRequestAnimationFrame?: typeof requestAnimationFrame;
-  webkitRequestAnimationFrame?: typeof requestAnimationFrame;
-  oRequestAnimationFrame?: typeof requestAnimationFrame;
-  mozCancelAnimationFrame?: typeof cancelAnimationFrame;
-  webkitCancelAnimationFrame?: typeof cancelAnimationFrame;
-  oCancelAnimationFrame?: typeof cancelAnimationFrame;
-}
-
-// 类型安全的 window 引用
-const extendedWindow = window as ExtendedWindow;
-
-// Request animation frame polyfills
-export const reqAnimFrame = extendedWindow.requestAnimationFrame || 
-  extendedWindow.mozRequestAnimationFrame || 
-  extendedWindow.webkitRequestAnimationFrame || 
-  extendedWindow.oRequestAnimationFrame;
-
-export const cancelAnimFrame = extendedWindow.cancelAnimationFrame || 
-  extendedWindow.mozCancelAnimationFrame || 
-  extendedWindow.webkitCancelAnimationFrame || 
-  extendedWindow.oCancelAnimationFrame;
-
 import { NormalizedStyle, StyleAttributes, Transform, CurveData } from './types';
 
 // Calculate style

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -254,6 +254,8 @@ export function curveCalc(curveFrom: CurveData, curveTo: CurveData, progress: nu
 }
 
 export function clone<T>(obj: T): T {
+  // TODO: 用 structuredClone 替换？需要调整浏览器支持情况！
+
   let copy: any;
 
   // Handle Array
@@ -287,16 +289,16 @@ const rgbToString = function (rgb: RGBColor): string {
   return "rgba(" + [round(rgb.r), round(rgb.g), round(rgb.b), +rgb.opacity.toFixed(2)] + ")";
 };
 
-interface RGBColorWithError extends RGBColor {
-  error?: number;
-}
-
 // Parses color string as RGB object
-const getRGB = function (doc: SVGSVGElement | null, colour: string): RGBColorWithError {
+const getRGB = function (doc: SVGSVGElement | null, colour: string): RGBColor {
   if (colour.toUpperCase() === 'CURRENTCOLOR') {
     const i = doc || window.document.getElementsByTagName('head')[0] || window.document.getElementsByTagName('svg')[0];
     if (i.style.color) {
-      colour = i.style.color;
+      if (i.style.color.toUpperCase() === 'CURRENTCOLOR') {
+        colour = window.getComputedStyle(i).getPropertyValue('color')!;
+      } else {
+        colour = i.style.color;
+      }
     } else {
       i.style.color = colour;
       colour = window.getComputedStyle(i).getPropertyValue('color')!;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export type {
   EasingFunction,
   SVGMorpheusOptions,
   StyleAttributes,
-  RGBColor,
   NormalizedStyle,
   Transform,
   IconItem,

--- a/src/svg-morpheus.ts
+++ b/src/svg-morpheus.ts
@@ -606,7 +606,7 @@ export class SVGMorpheus {
   }
 
   private _updateAnimationProgress(progress: number): void {
-    progress = easings[this._easing](progress);
+    progress = (easings as any)[this._easing](progress);
 
     let i: number, j: string, k: string, len: number;
     // Update path/attrs/transform
@@ -747,7 +747,7 @@ export class SVGMorpheus {
    * });
    */
   public registerEasing(name: string, fn: (progress: number) => number): void {
-    easings[name] = fn;
+    (easings as any)[name] = fn;
   }
 
   /**

--- a/src/svg-morpheus.ts
+++ b/src/svg-morpheus.ts
@@ -300,13 +300,13 @@ export class SVGMorpheus {
                       case 'stroke':
                       case 'stroke-opacity':
                       case 'stroke-width':
-                        (item.attrs as any)[name] = attrib.value;
+                        item.attrs[name] = attrib.value;
                     }
                   }
                 }
 
                 // Traverse all inline styles and get supported values
-                const elementStyle = (nodeItem as any).style;
+                const elementStyle = nodeItem.style;
                 for (let l = 0, len4 = elementStyle.length; l < len4; l++) {
                   const styleName = elementStyle[l];
                   switch (styleName) {
@@ -316,7 +316,7 @@ export class SVGMorpheus {
                     case 'stroke':
                     case 'stroke-opacity':
                     case 'stroke-width':
-                      (item.style as any)[styleName] = elementStyle[styleName];
+                      item.style[styleName] = elementStyle[l];
                   }
                 }
 
@@ -636,11 +636,11 @@ export class SVGMorpheus {
     for (i = 0, len = this._morphNodes.length; i < len; i++) {
       const morphNode = this._morphNodes[i];
       morphNode.node.setAttribute("d", this._curIconItems[i].path);
-      const attrs = this._curIconItems[i].attrs as StyleAttributes;
+      const attrs = this._curIconItems[i].attrs;
       for (j in attrs) {
         morphNode.node.setAttribute(j, (attrs as any)[j]);
       }
-      const style = this._curIconItems[i].style as StyleAttributes;
+      const style = this._curIconItems[i].style;
       for (k in style) {
         (morphNode.node.style as any)[k] = (style as any)[k];
       }
@@ -656,7 +656,7 @@ export class SVGMorpheus {
         morphNode.node.setAttribute("d", this._toIconItems[i].path);
         
         // 设置最终的attributes（包含更新后的defs引用）
-        const attrs = this._toIconItems[i].attrs as StyleAttributes;
+        const attrs = this._toIconItems[i].attrs;
         for (const attrName in attrs) {
           morphNode.node.setAttribute(attrName, (attrs as any)[attrName]);
         }

--- a/src/svg-morpheus.ts
+++ b/src/svg-morpheus.ts
@@ -519,14 +519,14 @@ export class SVGMorpheus {
         toIconItem.curve = curves[1];
 
         // Normalize from/to attrs
-        const attrsNorm = styleToNorm(this._fromIconItems[i].attrs, this._toIconItems[i].attrs);
+        const attrsNorm = styleToNorm(this._fromIconItems[i].attrs, this._toIconItems[i].attrs, this._svgDoc);
         fromIconItem.attrsNorm = attrsNorm[0];
         toIconItem.attrsNorm = attrsNorm[1];
         fromIconItem.attrs = styleNormToString(fromIconItem.attrsNorm);
         toIconItem.attrs = styleNormToString(toIconItem.attrsNorm);
 
         // Normalize from/to style
-        const styleNorm = styleToNorm(this._fromIconItems[i].style, this._toIconItems[i].style);
+        const styleNorm = styleToNorm(this._fromIconItems[i].style, this._toIconItems[i].style, this._svgDoc);
         fromIconItem.styleNorm = styleNorm[0];
         toIconItem.styleNorm = styleNorm[1];
         fromIconItem.style = styleNormToString(fromIconItem.styleNorm);

--- a/src/svg-morpheus.ts
+++ b/src/svg-morpheus.ts
@@ -6,8 +6,6 @@ import {
   trans2string, 
   curveCalc, 
   clone,
-  reqAnimFrame,
-  cancelAnimFrame,
   extractViewBoxInfo,
   extractDefsInfo,
   extractSvgRootAttributes
@@ -133,7 +131,7 @@ export class SVGMorpheus {
       const progress = Math.min((timePassed - that._startTime) / that._duration, 1);
       that._updateAnimationProgress(progress);
       if (progress < 1) {
-        that._rafid = reqAnimFrame(that._fnTick);
+        that._rafid = window.requestAnimationFrame(that._fnTick);
       } else {
         if (that._toIconId !== '') {
           that._animationEnd();
@@ -715,7 +713,7 @@ export class SVGMorpheus {
       }
 
       if (this._rafid) {
-        cancelAnimFrame(this._rafid);
+        window.cancelAnimationFrame(this._rafid);
       }
 
       this._duration = options.duration || this._defDuration;
@@ -724,7 +722,7 @@ export class SVGMorpheus {
       this._callback = callback || this._defCallback;
 
       this._setupAnimation(iconId);
-      this._rafid = reqAnimFrame(this._fnTick);
+      this._rafid = window.requestAnimationFrame(this._fnTick);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import Color from 'colorjs.io';
+
 // Animation easing functions | 动画缓动函数类型
 export type EasingFunction = (t: number) => number;
 
@@ -41,31 +43,19 @@ export interface SVGMorpheusOptions {
 // Style attributes for SVG elements | SVG 元素样式属性
 export interface StyleAttributes {
   fill?: string;
-  'fill-opacity'?: string;
-  opacity?: string;
   stroke?: string;
+  opacity?: string;
+  'fill-opacity'?: string;
   'stroke-opacity'?: string;
   'stroke-width'?: string;
-}
-
-// Normalized color object | 标准化颜色对象
-export interface RGBColor {
-  /** Red channel (0-255) | 红色通道 (0-255) */
-  r: number;
-  /** Green channel (0-255) | 绿色通道 (0-255) */
-  g: number;
-  /** Blue channel (0-255) | 蓝色通道 (0-255) */
-  b: number;
-  /** Opacity (0-1) | 透明度 (0-1) */
-  opacity: number;
 }
 
 // Normalized style values | 标准化样式值
 export interface NormalizedStyle {
   /** Fill color or gradient reference | 填充颜色或渐变引用 */
-  fill?: RGBColor | string;
+  fill?: Color | string;
   /** Stroke color or gradient reference | 描边颜色或渐变引用 */
-  stroke?: RGBColor | string;
+  stroke?: Color | string;
   /** Overall opacity | 整体透明度 */
   opacity?: number;
   /** Fill opacity | 填充透明度 */


### PR DESCRIPTION
作了以下修改：
 - 导出对象 easings 带有明确的字段名称，使用者可以通过 keyof easings 获取字段名；
 - 引入 colorjs.io，基本支持所有的 CSS 颜色类型；
 - 同时采用 colorjs.io 中的 Color 对象代替了原来自定义的 RGBColor 和 RGBColorWithError；
 - 删除了 reqAnimFrame 和 cancelAnimFrame，最低版本的浏览器已经完全支持此功能，没必要作这些 hack；